### PR TITLE
Require a TPM.

### DIFF
--- a/server_platform.bib
+++ b/server_platform.bib
@@ -55,3 +55,7 @@
   url = {https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/extensible-host-controler-interface-usb-xhci.pdf},
   year = {}
 }
+@electronic{TPM20,
+  title = {TPM 2.0 Library},
+  url = {https://trustedcomputinggroup.org/resource/tpm-library-specification/}
+}

--- a/server_platform_requirements.adoc
+++ b/server_platform_requirements.adoc
@@ -125,6 +125,7 @@ PCIe devices or be compliant to rules for SoC-integrated PCIe devices (cite:[Ser
 
              * Support 64-bit addressing (S64A = '1').
 | `HPER_070`   | A battery-backed RTC or analogous timekeeping mechanism MUST be implemented.
+| `HPER_080`   | A Trusted Platform Module (TPM) MUST be implemented and adhere to the TPM 2.0 Library specification cite:[TPM20].
 |===
 
 == Server Platform Firmware Requirements

--- a/server_platform_tests.adoc
+++ b/server_platform_tests.adoc
@@ -88,6 +88,7 @@
 | `MF_HPER_050_010` | _FIXME AHCI test validating register values_.
 | `MF_HPER_060_010` | _FIXME AHCI test validating register values_.
 | `MF_HPER_070_010` | _FIXME UEFI RT based test_.
+| `MF_HPER_080_010` | _FIXME_.
 |===
 
 <<<


### PR DESCRIPTION
Added to the existing peripherals section, since it is a peripheral. There will probably be a security section, but that should contain guarantees/apparent behavior.