### PR TITLE
RVA_020: Provide additional context for Ssccfg

### DIFF
--- a/server_platform_requirements.adoc
+++ b/server_platform_requirements.adoc
@@ -26,7 +26,6 @@ in this section apply solely to harts in the application processors of the SoC.
              * Ssccfg
              * Sscsrind
              * Ssstrict
-             * Smcntrpmf
              * Ssaia
 
 2+| _Many of these mandated extensions are optional in the RVA23 ISA profile.


### PR DESCRIPTION
The privileged specification includes a chapter about "Smcdeleg" Counter Delegation Extension, Version 1.0.0 that includes the description of Smcdeleg and Ssccfg.

For clarity / ease of finding the the details, update the RVA_020 requirement to include a reference to Smcdeleg.

Closes: #19 