### PR TITLE
Add requirement of having at least one valid boot method

### DIFF
--- a/server_platform_requirements.adoc
+++ b/server_platform_requirements.adoc
@@ -143,6 +143,7 @@ PCIe devices or be compliant to rules for SoC-integrated PCIe devices (cite:[Ser
 | `FIRM_090` | MUST support the installation of Load Option Variables (+Boot####, or Driver####, or SysPrep####+) consistent with cite:[UEFI] Section 2.6.2.
 | `FIRM_100` | MUST support the ability to register for notifications when a call to ResetSystem is called, consistent with cite:[UEFI] Section 2.6.2.
 | `FIRM_110` | If an IOMMU is present, then it MUST be described using the RIMT ACPI table cite:[RIMT].
+| `FIRM_120` | MUST support at least one of `FIRM_030`, `FIRM_040`, `FIRM_080` to provide at least one valid boot method.
 |===
 
 == Server Platform Security Requirements


### PR DESCRIPTION
This a trivial requirement proposal:

Currently, the specifications have multiple "SHOULD" requirements for boot methods.
There is no "MUST" boot method. 

Obviously, a server that could not boot is not going to be very useful and no manufacturer are going to build hardware that cannot boot but for consistencies reasons, I propose a requirement `FIRM_120` to require at least one of `FIRM_030`, `FIRM_040`, `FIRM_080`.