### PR TITLE
Clarify the purpose of the UART in HPER_010

### DIFF
--- a/server_platform_requirements.adoc
+++ b/server_platform_requirements.adoc
@@ -101,8 +101,14 @@ PCIe devices or be compliant to rules for SoC-integrated PCIe devices (cite:[Ser
 [%header, cols="5,25"]
 |===
 | ID#       ^| Requirement
-| `HPER_010`   | For remote-access and system engineering purposes, a fully 16550-compatible cite:[NS16550] UART MUST be implemented.
-2+| _This is a stronger requirement than the Server SoC `MNG_030` requirement cite:[ServerSoC]. This specification does not provide guidance around how the UART is physically exposed, i.e. via RS232 signalling, USB, a BMC or other mechanism._
+| `HPER_010`   | For remote-access and system engineering purposes in early boot software, a fully 16550-compatible cite:[NS16550] UART MUST be implemented.
+2+| _This is a stronger requirement than the Server SoC `MNG_030` requirement
+    cite:[ServerSoC].  The intention here is to simplify early boot software
+    support requirements.  This UART is not intended to be directly assignable
+    to virtual machines, and thus there is no requirement for this UART to
+    appear as a PCI device.  This specification does not provide guidance around
+    how the UART is physically exposed, i.e. via RS232 signalling, USB, a BMC or
+    other mechanism._
 | `HPER_020`  a| The implemented UART MUST support:
 
               * Interrupt-driven operation using a wired interrupt.


### PR DESCRIPTION
HPER_010 doesn't state the purpose for the UART that is mentioned there. Apparently the intended use case is to ease the software interface for early boot logging and debugging, so let's state that explicitly.

See issue #37 for more information.