### PR TITLE
FIRM_060: Clarify the ISA for option ROM support

### DIFF
--- a/server_platform_requirements.adoc
+++ b/server_platform_requirements.adoc
@@ -137,7 +137,7 @@ PCIe devices or be compliant to rules for SoC-integrated PCIe devices (cite:[Ser
 | `FIRM_040`  | SHOULD include the ability to perform a TFTP-based boot from a network device and to validate a boot
     image received through a network device, supporting relevant protocols (cite:[UEFI] Section 2.6.2).
 | `FIRM_050`  | SHOULD support UEFI general purpose network applications, including IPv4, IPv6, DNS, TLS, IPSec and VLAN features, supporting relevant protocols (cite:[UEFI] Section 2.6.2).
-| `FIRM_060`  | MUST support option ROMs from devices not permanently attached to the platform, including the ability to authenticate these option ROMs (cite:[UEFI] Section 2.6.2).
+| `FIRM_060`  | MUST support x86 ISA option ROMs from devices not permanently attached to the platform, including the ability to authenticate these option ROMs (cite:[UEFI] Section 2.6.2).
 | `FIRM_070` | SHOULD support 64-bit Intel architecture (aka x64, aka AMD64) UEFI option ROM drivers for improved compatiblity with third-party IHV ecosystem.
 | `FIRM_080` | SHOULD support the ability to perform a HTTP-based boot from a network device, including support for HTTPS and DNS, supporting relevant HII protocols (cite:[UEFI] Section 2.6.2).
 | `FIRM_090` | MUST support the installation of Load Option Variables (+Boot####, or Driver####, or SysPrep####+) consistent with cite:[UEFI] Section 2.6.2.


### PR DESCRIPTION
FIRM_060 should specify what types of option ROMs are supported, for example,  what option ROM ISAs must be usable. Presumably this is meant to support x86  option ROMs; so, state this here.

See issue #41.