### PR TITLE
FIRM_090, FIRM_100: clarify what entities are permitted

### DIFF
--- a/server_platform_requirements.adoc
+++ b/server_platform_requirements.adoc
@@ -140,8 +140,8 @@ PCIe devices or be compliant to rules for SoC-integrated PCIe devices (cite:[Ser
 | `FIRM_060`  | MUST support option ROMs from devices not permanently attached to the platform, including the ability to authenticate these option ROMs (cite:[UEFI] Section 2.6.2).
 | `FIRM_070` | SHOULD support 64-bit Intel architecture (aka x64, aka AMD64) UEFI option ROM drivers for improved compatiblity with third-party IHV ecosystem.
 | `FIRM_080` | SHOULD support the ability to perform a HTTP-based boot from a network device, including support for HTTPS and DNS, supporting relevant HII protocols (cite:[UEFI] Section 2.6.2).
-| `FIRM_090` | MUST support the installation of Load Option Variables (+Boot####, or Driver####, or SysPrep####+) consistent with cite:[UEFI] Section 2.6.2.
-| `FIRM_100` | MUST support the ability to register for notifications when a call to ResetSystem is called, consistent with cite:[UEFI] Section 2.6.2.
+| `FIRM_090` | MUST support software that runs from EFI firmware to install Load Option Variables (+Boot####, or Driver####, or SysPrep####+) consistent with cite:[UEFI] Section 2.6.2.
+| `FIRM_100` | MUST support software that runs from EFI firmware to register for notifications when a call to ResetSystem is called, consistent with cite:[UEFI] Section 2.6.2.
 | `FIRM_110` | If an IOMMU is present, then it MUST be described using the RIMT ACPI table cite:[RIMT].
 |===
 


### PR DESCRIPTION
For FIRM_090 and FIRM_100, it is unclear what entities on the system would be  allowed to install Load Option Variables or to register for ResetSystem  notifications.  Let's make an assumption here about what entities can do this, and clarify this in the text.

See issue #43.