### PR TITLE
FIRM: simplify calls to UEFI runtime services

### DIFF
--- a/server_platform_requirements.adoc
+++ b/server_platform_requirements.adoc
@@ -151,6 +151,10 @@ PCIe devices or be compliant to rules for SoC-integrated PCIe devices (cite:[Ser
 | `FIRM_090` | The firmware MUST support software that runs from EFI firmware to install Load Option Variables (+Boot####, or Driver####, or SysPrep####+) consistent with cite:[UEFI_platform_specific] number 27.
 | `FIRM_100` | The firmware MUST support software that runs from EFI firmware to register for notifications when a call to ResetSystem is called, consistent with cite:[UEFI_platform_specific] number 32.
 | `FIRM_110` | If an IOMMU is present, then it MUST be described using the RIMT ACPI table cite:[RIMT].
+| `FIRM_120` | If the firmware allows forward-edge control-flow integrity (FCFI) to be enabled for the supervisor execution environment, the runtime services MUST be compiled to support FCFI.
+2+| _The supervisor execution environment SHOULD enable FCFI through the SBI FWFT LANDING_PAD interface._
+| `FIRM_130` | The support for forward-edge control-flow integrity in runtime services MUST be signaled by the EFI_MEMORY_ATTRIBUTES_FLAGS_RT_FORWARD_CONTROL_FLOW_GUARD flag (cite:[UEFI] Section 4.6.3 EFI_MEMORY_ATTRIBUTES_TABLE).
+| `FIRM_140` | If the runtime services support forward-edge control-flow integrity, the instruction at the entry address of any runtime service MUST be a 4-byte aligned, unlabeled landing pad (`lpad 0`).
 |===
 
 == Server Platform Security Rules


### PR DESCRIPTION
Without this rule, the worst case is that the OS would have to toggle landing pads through SBI FWFT around every call to a UEFI runtime service.