### PR TITLE
Introduction: Reinforce that a primary goal of this specification is to enable software interoperability with conforming servers

### DIFF
--- a/server_platform_intro.adoc
+++ b/server_platform_intro.adoc
@@ -36,7 +36,10 @@ manageability specifications like MCTP, PLDM, Redfish, and IPMI for functions su
 as power management, telemetry, debug, and provisioning. The platform security model
 includes guidelines and requirements for aspects such as debug authorization,
 secure/measured boot, firmware updates, firmware resilience, and confidential
-computing, among others.
+computing, among others.  A primary goal of this specification is to enable
+interoperability between conforming servers and the large ecosystem of
+portable system software, available from a variety of sources, such that
+conforming servers are not limited to any single system software distribution.
 
 The platform firmware, typically operating at privilege level M, is
 considered part of the platform and is usually expected to be customized and


### PR DESCRIPTION
As discussed in our 2025-07-06 meeting, for the avoidance of doubt, highlight that a primary goal of this specification is to enable interoperability between servers that conform to this specification and a large ecosystem of portable system software, rather than any specific individual system software distribution.