### PR TITLE
RVA_050: clarify that identifiers can be used to distinguish the harts

### DIFF
--- a/server_platform_requirements.adoc
+++ b/server_platform_requirements.adoc
@@ -53,7 +53,8 @@ in this section apply solely to harts in the application processors of the SoC.
      environment allows system software to migrate tasks among the harts without
      constraints._
 
-| `RVA_050`  | The RISC-V application processor harts in the SoC MAY support
+| `RVA_050`  | The RISC-V application processor harts in the SoC MAY have different
+             microarchitecture identifiers (mvendorid, marchid, and mimpid) and MAY support
              different power and performance characteristics but MUST be
              otherwise indistinguishable from each other from a software
              execution viewpoint within a supervisor execution environment (SEE).


### PR DESCRIPTION
As agreed in the server platform meeting, the current wording is too strong, because the harts are expected to differ in product identifiers.

The harts must also differ in hart id, but that one is not explicitly called as the architecture would not be RISC-V otherwise, and it's also not directly accessible through SBI ecall (it is getting passed in a register at boot).

The spirit of the rule is to make sure that the OS doesn't have to jump through hoops to find a reasonable configuration that would work across all harts.