### PR TITLE
ME_RVA_010_010: do not assume hart 0 is exposed via RHTC

### DIFF
--- a/server_platform_tests.adoc
+++ b/server_platform_tests.adoc
@@ -13,8 +13,9 @@
                     . Determine the ISA node in ACPI RHCT table for that hart.
                     . Parse the ISA string in the ISA node and verify that all
                       mandatory extensions are supported.
-                    . Verify that the ISA string matches that of hart 0.
-                    . Report the ISA string of hart 0 into the test output log.
+                    . Verify that the ISA strings of all harts in the RHCT table
+                      are the same.
+                    . Report the ISA string.
 | `ME_RVA_020_010`  | See `T_RVA_010_010`.
 | `ME_RVA_030_010` a| . The `T_RVA_010_010` verifies that all ISA strings are
                       identical.


### PR DESCRIPTION
The server platform spec requires that all harts exposed to the operating systems support the same set of extensions. But there is no need for the first hart exposed to the operating system to be numbered 0.

E.g. hart 0 may be a management hart which is not exposed to the OS.

Closes #87 