### PR TITLE
[WIP] Move some Server SoC ACPI verification tests to Server Platform

### DIFF
--- a/server_platform_tests.adoc
+++ b/server_platform_tests.adoc
@@ -71,6 +71,61 @@
 |===
 | ID#            ^| Algorithm
 | `ME_HSOC_010_010` | The Server SoC tests must pass cite:[ServerSoCTest].
+| `MC_HSOC_010_020` | Parse the ACPI RHCT table to determine the firmware-reported
+		      time base frequency and verify it is equal to 1 GHz.
+
+		      This partially tests the product of the Server SoC
+		      requirement CTI_010 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
+| `MC_HSOC_010_030` | Locate the ACPI _LPI objects for each RISC-V application
+		      processor hart. If present, verify that the __Architectural
+		      Context Lost Flags__ have bit 0 set to 0, indicating no
+		      loss of timer context for each supported low-power idle
+		      state.
+
+		      This partially tests the product of the Server SoC
+		      requirement CTI_020 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
+| `MC_HSOC_010_040` | For each application processor hart:
+
+                      . Determine the ISA node in ACPI RHCT table for that hart.
+                      . Parse the ISA string in the ISA node and verify that Ssaia
+                        extension is supported.
+                      . Parse the RINTC structure in ACPI MADT tables to verify that
+                        the interrupt controller type for the hart is IMSIC.
+
+		      This partially tests the product of the Server SoC
+		      requirements IIC_010 and IIC_020 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
+| `MC_HSOC_010_050` | Verify the number of supported supervisor mode interrupt
+                      identities in IMSIC structure of the ACPI MADT table is at
+                      least 255.
+
+		      This partially tests the product of the Server SoC
+		      requirement IIC_050 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
+| `MC_HSOC_010_060` | Verify the number of supported guest mode interrupt
+                      identities in IMSIC structure of the ACPI MADT table is at
+                      least 63.
+
+		      This partially tests the product of the Server SoC
+		      requirement IIC_060 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
 | `ME_HSOC_020_010` | _FIXME_.
 |===
 
@@ -102,6 +157,61 @@
 |===
 | ID#            ^| Algorithm
 | `ME_FIRM_010_010` | The BRS-I tests must pass cite:[BRSTest].
+| `MC_FIRM_010_020` | Parse the ACPI RHCT table to determine the firmware-reported
+		      time base frequency and verify it is equal to 1 GHz.
+
+		      This partially tests the product of the Server SoC
+		      requirement CTI_010 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
+| `MC_FIRM_010_030` | Locate the ACPI _LPI objects for each RISC-V application
+		      processor hart. If present, verify that the __Architectural
+		      Context Lost Flags__ have bit 0 set to 0, indicating no
+		      loss of timer context for each supported low-power idle
+		      state.
+
+		      This partially tests the product of the Server SoC
+		      requirement CTI_020 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
+| `MC_FIRM_010_040` | For each application processor hart:
+
+                      . Determine the ISA node in ACPI RHCT table for that hart.
+                      . Parse the ISA string in the ISA node and verify that Ssaia
+                        extension is supported.
+                      . Parse the RINTC structure in ACPI MADT tables to verify that
+                        the interrupt controller type for the hart is IMSIC.
+
+		      This partially tests the product of the Server SoC
+		      requirements IIC_010 and IIC_020 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
+| `MC_FIRM_010_050` | Verify the number of supported supervisor mode interrupt
+                      identities in IMSIC structure of the ACPI MADT table is at
+                      least 255.
+
+		      This partially tests the product of the Server SoC
+		      requirement IIC_050 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
+| `MC_FIRM_010_060` | Verify the number of supported guest mode interrupt
+                      identities in IMSIC structure of the ACPI MADT table is at
+                      least 63.
+
+		      This partially tests the product of the Server SoC
+		      requirement IIC_060 (incorporated by reference
+		      in the Server Platform requirement HSOC_010) and
+		      the Boot & Runtime Services specification
+		      section 2.1 (incorporated by reference in the
+		      Server Platform requirement FIRM_010).
 | `ME_FIRM_020_010` | _FIXME_.
 | `ME_FIRM_030_010` | _FIXME_.
 | `ME_FIRM_040_010` | _FIXME_.

--- a/server_platform_ts_intro.adoc
+++ b/server_platform_ts_intro.adoc
@@ -3,18 +3,19 @@
 == Introduction
 
 The RISC-V Server Platform Test specification defines a set of tests to verify if the
-requirements specified in RISC-V Server Platform specification are implemented. The
-tests specified in this specification are not intended to exhaustively verify
-the implementation. In most cases the tests only check for existence of the
-feature. Future versions of this specification may include more exhaustive
-tests.
+requirements specified in the RISC-V Server Platform specification, along with
+specifications included by reference, are implemented. The tests specified in
+this specification are not intended to exhaustively verify the implementation.
+Future versions of this specification may include more exhaustive tests.
 
 The Server Platform specification builds on top of the Server SoC,
 Boot and Runtime Services and Platform Security specifications, which
 in turn have their own test specifications and/or compliance requirements.
 This test specification does not duplicate requirements in these dependent
-test specification, but provides additional tests on top the the tests
-already defined in these other documents.
+test specification, but provides additional tests on top of the tests
+already defined in these other documents.  This test specification does
+include overall platform tests requiring functionality that is first combined
+in this specification.
 
 The tests in this specification are documented use the following format:
 
@@ -36,11 +37,16 @@ The tests in this specification are documented use the following format:
                     log.                                                       +
                                                                                +
                     The character in position `B` indicates the nature of the 
-                    test. If this character is `F` then the test exercises some    
+                    test. If this character is `F` then the test exercises some
                     or all of the functionality associated with the feature. If
                     the character is `E` then the test determines for evidence 
                     that the feature is implemented (e.g., check ACPI tables) 
-                    but does not functionally exercise the feature.
+                    but does not functionally exercise the feature.  If the
+		    character is `C` then the test directly verifies
+		    requirements which can only be tested using a combination
+		    of features specified in the Server Platform document and/or
+		    features incorporated by reference from another
+		    specification.
                    
 |===
 


### PR DESCRIPTION
The Server SoC Test Specification contains some ACPI firmware tests that aren't directly specified by the Server SoC specification (which has nothing to do with ACPI), but which are specified by the Server Platform specification (often by references).  So, move these ACPI firmware tests into the Server Platform test specification.

This pull request is a work-in-progress and is not yet ready for merging.